### PR TITLE
Changed example code to use new Bool type

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class Person
       nested: {
         at: {
           any: Integer,
-          level: Boolean,
+          level: Bool,
         },
       },
     }


### PR DESCRIPTION
Seeing `Boolean` being used in the example caused me to trip up until I realized it's been renamed to `Bool`